### PR TITLE
[KED-2065] Add numpy dependency

### DIFF
--- a/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -12,4 +12,4 @@ pytest-cov>=2.5, <3.0
 pytest-mock>=1.7.1,<2.0
 pytest>=5.0, <6.0
 wheel==0.32.2
-numpy
+numpy>=1.7

--- a/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -12,3 +12,4 @@ pytest-cov>=2.5, <3.0
 pytest-mock>=1.7.1,<2.0
 pytest>=5.0, <6.0
 wheel==0.32.2
+numpy


### PR DESCRIPTION
The starter is not runnable without `numpy` as this is used by [`pyspark.ml`](https://github.com/apache/spark/blob/fc10511d15a17c091e977dc4759be96247a8433e/python/setup.py#L208)

It brings up the question why CI did not capture this, but that can be addressed in a separate PR.